### PR TITLE
Make pry-rails friendly to Rails 3.2

### DIFF
--- a/lib/pry-rails.rb
+++ b/lib/pry-rails.rb
@@ -1,16 +1,17 @@
+require 'rails'
 require "pry-rails/version"
 
 module PryRails
-  if defined? Rails && Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR >= 1
+  if defined? Rails && Rails::VERSION::MAJOR == 3 && Rails::VERSION::MINOR >= 0
     class Railtie < ::Rails::Railtie
       silence_warnings do
         begin
           require 'pry'
           ::IRB = Pry
-        rescue LoadError
+          IRB::ExtendCommandBundle = Pry
+          rescue LoadError 
         end
       end
     end
   end
 end
-

--- a/pry-rails.gemspec
+++ b/pry-rails.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   # s.add_development_dependency "rspec"
   # s.add_runtime_dependency "rest-client"
-  %w(pry pry-doc).each {|d| s.add_dependency d}
+  %w(pry pry-doc rails).each {|d| s.add_dependency d}
 end


### PR DESCRIPTION
Rails 3.2 makes use of IRB extensions (I think) and so invokes an additional IRB constant which throws a undefined constant error when starting up rails console. I would like to submit a small fix for the error.
