### PR TITLE
Rails 3.2 fixes

### DIFF
--- a/lib/pry-rails.rb
+++ b/lib/pry-rails.rb
@@ -7,7 +7,9 @@ module PryRails
         begin
           require 'pry'
           ::IRB = Pry
-          IRB::ExtendCommandBundle = Pry
+          unless defined?(IRB::ExtendCommandBundle)
+            IRB::ExtendCommandBundle = Module.new
+          end
         rescue LoadError
         end
       end


### PR DESCRIPTION
This patch fixes two issues with the `ExtendCommandBundle` change:
- Using `Pry` as the replacement class could break stuff in the future. There's no reason not to just use an empty module.
- The next version of Pry will have an empty `ExtendCommandBundle` module to address this issue, so pry-rails shouldn't overwrite it if it's already there.
