### PR TITLE
Add Rails methods back to pry-rails

### DIFF
--- a/lib/pry-rails.rb
+++ b/lib/pry-rails.rb
@@ -10,6 +10,11 @@ module PryRails
           unless defined?(IRB::ExtendCommandBundle)
             IRB::ExtendCommandBundle = Module.new
           end
+					if ::Rails::VERSION::MINOR >= 2
+						require "rails/console/app"
+						require "rails/console/helpers"
+						Object.send(:include, Rails::ConsoleMethods) 
+					end
         rescue LoadError
         end
       end


### PR DESCRIPTION
This pull request will enable methods like reload! to work again in pry-rails with Rails 3.2. 

Injecting the Rails::ConsoleMethods into Object isn't ideal (it is exactly what rails changed), but I don't see a cleaner Pry specific way. 

I also added a check to make sure this was only done with Rails 3.2+. Might want to add a gem dependency so only users with Rails 3.2 actually get this change. 
