### PR TITLE
Use TOPLEVEL_BINDING instead of adding to Object.

### DIFF
--- a/lib/pry-rails.rb
+++ b/lib/pry-rails.rb
@@ -13,7 +13,7 @@ module PryRails
 					if ::Rails::VERSION::MINOR >= 2
 						require "rails/console/app"
 						require "rails/console/helpers"
-						Object.send(:include, Rails::ConsoleMethods) 
+						TOPLEVEL_BINDING.eval('self').extend Rails::ConsoleMethods
 					end
         rescue LoadError
         end


### PR DESCRIPTION
Add Rails::ConsoleMethods methods to TOPLEVEL_BINDING instead of Object.
