### PR TITLE
Fix major bug in my last pull

### DIFF
--- a/lib/pry-rails.rb
+++ b/lib/pry-rails.rb
@@ -1,23 +1,26 @@
 require "pry-rails/version"
 
 module PryRails
-  if(defined?(::Rails) and ::Rails::VERSION::MAJOR >= 3)
-    class Railtie < ::Rails::Railtie
-      silence_warnings do
-        begin
-          require 'pry'
-          Rails::Console::IRB = Pry
+  begin
+    require 'pry'
+
+    if (defined?(::Rails::Console) and ::Rails::VERSION::MAJOR >= 3)
+      class Railtie < ::Rails::Railtie
+        silence_warnings do
+          ::Rails::Console::IRB = Pry
+
           unless defined?(Pry::ExtendCommandBundle)
             Pry::ExtendCommandBundle = Module.new
           end
+
           if ::Rails::VERSION::MINOR >= 2
             require "rails/console/app"
             require "rails/console/helpers"
-            TOPLEVEL_BINDING.eval('self').extend Rails::ConsoleMethods
+            TOPLEVEL_BINDING.eval('self').extend ::Rails::ConsoleMethods
           end
-        rescue LoadError
         end
       end
     end
+  rescue LoadError
   end
 end


### PR DESCRIPTION
My last pull request breaks Rails booting outside the console. This fixes it by only replacing IRB when we're actually in the console. An alternate fix would be to set Rails::IRB instead of Rails::Console::IRB, but this seems preferable.

Sorry about the issue. I'd recommend yanking the last gem and pushing this one immediately.
