### PR TITLE
Delayed require pry

### DIFF
--- a/lib/pry-rails.rb
+++ b/lib/pry-rails.rb
@@ -1,10 +1,7 @@
 # encoding: UTF-8
 
-require 'pry'
 require 'pry-rails/version'
 
 if defined?(Rails) && !ENV['DISABLE_PRY_RAILS']
   require 'pry-rails/railtie'
-  require 'pry-rails/commands'
-  require 'pry-rails/model_formatter'
 end

--- a/lib/pry-rails/railtie.rb
+++ b/lib/pry-rails/railtie.rb
@@ -5,6 +5,7 @@ module PryRails
     console do
       require 'pry'
       require 'pry-rails/commands'
+      require 'pry-rails/model_formatter'
 
       if Rails::VERSION::MAJOR == 3
         Rails::Console::IRB = Pry


### PR DESCRIPTION
Under spring booted environment, `rails console` starts pry console, but
console prompt doesn't show up until after hiting return

This issue occurs because

```
require 'pry'
```

requires readline too early.

Solve the issue by delaying to require pry into Railtie console callback.

closes #50 
refs rails/spring#244
