### PR TITLE
Add Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.2
 gemfile:
-  - gemfiles/rails30.gemfile 
-  - gemfiles/rails31.gemfile 
-  - gemfiles/rails32.gemfile 
-  - gemfiles/rails4.gemfile 
+  - gemfiles/rails30.gemfile
+  - gemfiles/rails31.gemfile
+  - gemfiles/rails32.gemfile
+  - gemfiles/rails4.gemfile
 matrix:
   exclude:
     - rvm: 1.9.2
-      gemfile: gemfiles/rails32.gemfile 
+      gemfile: gemfiles/rails32.gemfile
     - rvm: 1.9.2
-      gemfile: gemfiles/rails4.gemfile 
+      gemfile: gemfiles/rails4.gemfile


### PR DESCRIPTION
Would be great to know that Rails 2.1.2 is supported.
