### PR TITLE
warning: assigned but unused variable - e

### DIFF
--- a/lib/pry-rails/commands/show_models.rb
+++ b/lib/pry-rails/commands/show_models.rb
@@ -44,7 +44,7 @@ class PryRails::ShowModels < Pry::ClassCommand
 
       begin
         is_model = o.class == Class && o.ancestors.include?(Mongoid::Document)
-      rescue => e
+      rescue
         # If it's a weird object, it's not what we want anyway.
       end
 


### PR DESCRIPTION
Here's a quick fix against noisy Ruby :warning:.
