### PR TITLE
define all commands as subclasses of 'Pry::ClassCommand'

### DIFF
--- a/lib/pry-rails/commands/recognize_path.rb
+++ b/lib/pry-rails/commands/recognize_path.rb
@@ -1,28 +1,26 @@
-# encoding: UTF-8
+class PryRails::RecognizePath < Pry::ClassCommand
+  match 'recognize-path'
+  group 'Rails'
+  description 'See which route matches a URL.'
+  banner <<-BANNER
+    Usage: recognize-path <path> [-m|--method METHOD]
 
-PryRails::Commands.create_command "recognize-path" do
-  group "Rails"
-  description "See which route matches a URL."
+    Verifies that a given path is mapped to the right controller and action.
+
+    recognize-path example.com
+    recognize-path example.com -m post
+  BANNER
 
   def options(opt)
-    opt.banner unindent <<-USAGE
-      Usage: recognize-path <path> [-m|--method METHOD]
-
-      Verifies that a given path is mapped to the right controller and action.
-
-      recognize-path example.com
-      recognize-path example.com -m post
-    USAGE
-
     opt.on :m, :method, "Methods", :argument => true
   end
 
-  def process
+  def process(path)
     method = (opts.m? ? opts[:m] : :get)
     routes = Rails.application.routes
 
     begin
-      info = routes.recognize_path("http://#{args.first}", :method => method)
+      info = routes.recognize_path("http://#{path}", :method => method)
     rescue ActionController::UnknownHttpMethod
       output.puts "Unknown HTTP method: #{method}"
     rescue ActionController::RoutingError => e
@@ -31,4 +29,6 @@ PryRails::Commands.create_command "recognize-path" do
 
     output.puts Pry::Helpers::BaseHelpers.colorize_code(info)
   end
+
+  PryRails::Commands.add_command(self)
 end

--- a/lib/pry-rails/commands/show_middleware.rb
+++ b/lib/pry-rails/commands/show_middleware.rb
@@ -1,20 +1,18 @@
-# encoding: UTF-8
+class PryRails::ShowMiddleware < Pry::ClassCommand
+  match 'show-middleware'
+  group 'Rails'
+  description 'Show all middleware (that Rails knows about).'
+  banner <<-BANNER
+    Usage: show-middleware [-G]
 
-PryRails::Commands.create_command "show-middleware" do
-  group "Rails"
-  description "Show all middleware (that Rails knows about)."
+    show-middleware shows the Rails app's middleware.
+
+    If this pry REPL is attached to a Rails server, the entire middleware
+    stack is displayed.  Otherwise, only the middleware Rails knows about is
+    printed.
+  BANNER
 
   def options(opt)
-    opt.banner unindent <<-USAGE
-      Usage: show-middleware [-G]
-
-      show-middleware shows the Rails app's middleware.
-
-      If this pry REPL is attached to a Rails server, the entire middleware
-      stack is displayed.  Otherwise, only the middleware Rails knows about is
-      printed.
-    USAGE
-
     opt.on :G, "grep", "Filter output by regular expression", :argument => true
   end
 
@@ -64,4 +62,6 @@ PryRails::Commands.create_command "show-middleware" do
       output.puts string
     end
   end
+
+  PryRails::Commands.add_command(self)
 end

--- a/lib/pry-rails/commands/show_routes.rb
+++ b/lib/pry-rails/commands/show_routes.rb
@@ -1,16 +1,13 @@
-# encoding: UTF-8
-
-PryRails::Commands.create_command "show-routes" do
-  group "Rails"
-  description "Show all routes in match order."
+class PryRails::ShowRoutes < Pry::ClassCommand
+  match 'show-routes'
+  group 'Rails'
+  description 'Show all routes in match order.'
+  banner <<-BANNER
+    Usage: show-routes [-G]
+    show-routes displays the current Rails app's routes.
+  BANNER
 
   def options(opt)
-    opt.banner unindent <<-USAGE
-      Usage: show-routes [-G]
-
-      show-routes displays the current Rails app's routes.
-    USAGE
-
     opt.on :G, "grep", "Filter output by regular expression", :argument => true
   end
 
@@ -61,4 +58,6 @@ PryRails::Commands.create_command "show-routes" do
     require 'action_dispatch/routing/inspector'
     ActionDispatch::Routing::RoutesInspector.new(all_routes).format(ActionDispatch::Routing::ConsoleFormatter.new).split(/\n/)
   end
+
+  PryRails::Commands.add_command(self)
 end


### PR DESCRIPTION
I noticed recognize-path, show-middleware, and show-routes used 'create_command'
to define commands while the show-model and show-models commands are defined as
subclasses of Pry::ClassCommand.

I think Pry::ClassCommand subclasses are slightly more clean, and makes the
definition of commands consistent throughout the project.
