### PR TITLE
require an argument for the 'recognize-path' command

### DIFF
--- a/lib/pry-rails/commands/recognize_path.rb
+++ b/lib/pry-rails/commands/recognize_path.rb
@@ -3,6 +3,7 @@
 PryRails::Commands.create_command "recognize-path" do
   group "Rails"
   description "See which route matches a URL."
+  command_options argument_required: true
 
   def options(opt)
     opt.banner unindent <<-USAGE


### PR DESCRIPTION
before:

```
[1] pry(main)> recognize-path
bad URI(absolute but no path): http://
```

after:

```
[1] pry(main)> recognize-path
Error: The command 'recognize-path' requires an argument.
```
