### PR TITLE
Feature/find route

### DIFF
--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "4.2.0beta4"
+gem "rails", "~> 4.2.0"
 gem "mongoid"
 gem "sqlite3"
 

--- a/lib/pry-rails/commands/find_route.rb
+++ b/lib/pry-rails/commands/find_route.rb
@@ -61,7 +61,7 @@ class PryRails::FindRoute < Pry::ClassCommand
         end
         result << "\n"
       end
-      _pry_.pager.page result
+      stagger_output result
     else
       output.puts "No routes found."
     end

--- a/lib/pry-rails/commands/find_route.rb
+++ b/lib/pry-rails/commands/find_route.rb
@@ -1,0 +1,78 @@
+class PryRails::FindRoute < Pry::ClassCommand
+  match 'find-route'
+  group 'Rails'
+  description 'See which URLs match a given Controller.'
+  command_options argument_required: true
+  banner <<-BANNER
+    Usage: find-route <controller>
+
+    Returns the URL(s) that match a given controller or controller action.
+
+    find-route MyController#show  #=> The URL that matches the MyController show action
+    find-route MyController       #=> All the URLs that hit MyController
+    find-route Admin              #=> All the URLs that hit the Admin namespace
+  BANNER
+
+  def process(controller)
+    if single_action?(controller)
+      single_action(controller)
+    else
+      all_actions(controller)
+    end
+  end
+
+  private
+
+  def single_action(controller)
+    controller_action_pair = controller_and_action_from(controller)
+    route = routes.find { |route| route.defaults == controller_action_pair }
+    show_routes(Array(route))
+  end
+
+  def all_actions(controller)
+    all_routes = routes.select do |route|
+      route.defaults[:controller].to_s.starts_with?(normalize_controller_name(controller))
+    end
+
+    show_routes(all_routes)
+  end
+
+  def controller_and_action_from(method_name)
+    controller, action = method_name.split("#")
+    {controller: normalize_controller_name(controller), action: action}
+  end
+
+  def routes
+    Rails.application.routes.routes
+  end
+
+  def normalize_controller_name(controller)
+    controller.underscore.chomp('_controller')
+  end
+
+  def show_routes(all_routes)
+    if all_routes.any?
+      grouped_routes = all_routes.group_by { |route| route.defaults[:controller] }
+      grouped_routes.each do |controller, routes|
+        output.puts "Routes for " + text.bold(controller.camelize + "Controller")
+        output.puts "--"
+        routes.each do |route|
+          output.puts "#{text.bold(verb_for(route))} #{route.defaults[:action]} #{route.path.spec}"
+        end
+        output.puts
+      end
+    else
+      output.puts "No routes found."
+    end
+  end
+
+  def verb_for(route)
+    %w(GET PUT POST PATCH DELETE).find { |v| route.verb =~ v }
+  end
+
+  def single_action?(controller)
+    controller =~ /#/
+  end
+
+  PryRails::Commands.add_command(self)
+end

--- a/lib/pry-rails/commands/find_route.rb
+++ b/lib/pry-rails/commands/find_route.rb
@@ -57,7 +57,7 @@ class PryRails::FindRoute < Pry::ClassCommand
         output.puts "Routes for " + text.bold(controller.camelize + "Controller")
         output.puts "--"
         routes.each do |route|
-          output.puts "#{text.bold(verb_for(route))} #{route.defaults[:action]} #{route.path.spec}"
+          output.puts "#{route.defaults[:action]} #{text.bold(verb_for(route))} #{route.path.spec}"
         end
         output.puts
       end

--- a/lib/pry-rails/commands/find_route.rb
+++ b/lib/pry-rails/commands/find_route.rb
@@ -53,14 +53,15 @@ class PryRails::FindRoute < Pry::ClassCommand
   def show_routes(all_routes)
     if all_routes.any?
       grouped_routes = all_routes.group_by { |route| route.defaults[:controller] }
-      grouped_routes.each do |controller, routes|
-        output.puts "Routes for " + text.bold(controller.camelize + "Controller")
-        output.puts "--"
+      result = grouped_routes.each_with_object("") do |(controller, routes), result|
+        result << "Routes for " + text.bold(controller.camelize + "Controller") + "\n"
+        result << "--\n"
         routes.each do |route|
-          output.puts "#{route.defaults[:action]} #{text.bold(verb_for(route))} #{route.path.spec}"
+          result << "#{route.defaults[:action]} #{text.bold(verb_for(route))} #{route.path.spec}" + "\n"
         end
-        output.puts
+        result << "\n"
       end
+      _pry_.pager.page result
     else
       output.puts "No routes found."
     end

--- a/lib/pry-rails/commands/find_route.rb
+++ b/lib/pry-rails/commands/find_route.rb
@@ -25,8 +25,8 @@ class PryRails::FindRoute < Pry::ClassCommand
 
   def single_action(controller)
     controller_action_pair = controller_and_action_from(controller)
-    route = routes.find { |route| route.defaults == controller_action_pair }
-    show_routes(Array(route))
+    route = routes.select { |route| route.defaults == controller_action_pair }
+    show_routes(route)
   end
 
   def all_actions(controller)

--- a/lib/pry-rails/commands/find_route.rb
+++ b/lib/pry-rails/commands/find_route.rb
@@ -77,3 +77,5 @@ class PryRails::FindRoute < Pry::ClassCommand
 
   PryRails::Commands.add_command(self)
 end
+
+PryRails::Commands.alias_command "find-routes", "find-route"

--- a/lib/pry-rails/commands/find_route.rb
+++ b/lib/pry-rails/commands/find_route.rb
@@ -37,8 +37,8 @@ class PryRails::FindRoute < Pry::ClassCommand
     show_routes(all_routes)
   end
 
-  def controller_and_action_from(method_name)
-    controller, action = method_name.split("#")
+  def controller_and_action_from(controller_and_action)
+    controller, action = controller_and_action.split("#")
     {controller: normalize_controller_name(controller), action: action}
   end
 


### PR DESCRIPTION
This PR adds the `find-route` command. It shows the URLs that match a given controller or controller/action pair. It is also able to show all routes that lie under a namespace.

See screenshot below:

![foo](http://i.imgur.com/szm5Y8X.png)