### PR TITLE
Enhance find-routes

### DIFF
--- a/lib/pry-rails/version.rb
+++ b/lib/pry-rails/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 
 module PryRails
-  VERSION = "0.3.3"
+  VERSION = "0.3.4"
 end


### PR DESCRIPTION
* Allow full regex match of argument, e.g  `find-routes comm` will show routes for CommentsController
* Include the route helper in the output, e.g index GET /admin/users/:user_id/comments(.:format)  [admin_user_comments]