### PR TITLE
Specify ruby 1.9 or greater required for gem.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@ This is a small gem which causes `rails console` to open [pry](http://pry.github
 # Prerequisites
 
 - A Rails >= 3.0 Application
+- Ruby >= 1.9
 
 # Installation
 

--- a/pry-rails.gemspec
+++ b/pry-rails.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/rweng/pry-rails"
   s.summary     = %q{Use Pry as your rails console}
   s.license     = "MIT"
+  s.required_ruby_version = ">= 1.9.1"
   # s.description = %q{TODO: Write a gem description}
 
   # s.rubyforge_project = "pry-rails"


### PR DESCRIPTION
Ran into an issue that cost me a few minutes using pry-rails, so I figured it wouldn't be bad to make it more explicit in the gemspec that Ruby 1.9 or greater is required, and shows up as a dependency in ruby gems.  I was able to use version 0.2.2 just fine with a Ruby 1.8.7/ Rails 3.2 app.  We're almost done upgrading to Ruby 2.2 for that app, but I figure there's plenty of sites still on 1.8.7 or earlier.  Great gem by the way.