### PR TITLE
Fix link to pry-everywhere article

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,4 +91,4 @@ appraisal:rails31`, `rake appraisal:rails32`, etc.
 # Alternative
 
 If you want to enable pry everywhere, make sure to check out
-[pry everywhere](http://lucapette.me/pry-everywhere/).
+[pry everywhere](http://lucapette.me/pry-everywhere).


### PR DESCRIPTION
Trailing slash lead to a 404 Not Found. Removed it.