### PR TITLE
Add Rails prompt

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,6 +76,16 @@ $ DISABLE_PRY_RAILS=1 rails console
 irb(main):001:0>
 ```
 
+## Custom Rails prompt
+
+If you want to include the current Rails environment and project name in the pry prompt, put the following lines in your project's `.pryrc`:
+
+```ruby
+if defined?(PryRails::RAILS_PROMPT)
+  Pry.config.prompt = PryRails::RAILS_PROMPT
+end
+```
+
 # Developing and Testing
 
 To generate Gemfiles for Rails 3.0, 3.1, 3.2, 4.0, 4.1, and 4.2, run `rake

--- a/lib/pry-rails.rb
+++ b/lib/pry-rails.rb
@@ -7,4 +7,5 @@ if defined?(Rails) && !ENV['DISABLE_PRY_RAILS']
   require 'pry-rails/railtie'
   require 'pry-rails/commands'
   require 'pry-rails/model_formatter'
+  require 'pry-rails/prompt'
 end

--- a/lib/pry-rails/prompt.rb
+++ b/lib/pry-rails/prompt.rb
@@ -1,0 +1,35 @@
+module PryRails
+  class Prompt
+    class << self
+      def formatted_env
+        if Rails.env.production?
+          bold_env = Pry::Helpers::Text.bold(Rails.env)
+          Pry::Helpers::Text.red(bold_env)
+        elsif Rails.env.development?
+          Pry::Helpers::Text.green(Rails.env)
+        else
+          Rails.env
+        end
+      end
+
+      def project_name
+        File.basename(Rails.root)
+      end
+    end
+  end
+
+  RAILS_PROMPT = proc do |target_self, nest_level, pry|
+    "[#{pry.input_array.size}] " \
+      "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
+      "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+      "#{":#{nest_level}" unless nest_level.zero?}> "
+  end
+
+  Pry::Prompt::MAP["rails"] = {
+    value: RAILS_PROMPT,
+    description: "Includes the current Rails environment and project folder name.\n" \
+                 "[1] [project_name][Rails.env] pry(main)>"
+  }
+end
+
+Pry.config.prompt = PryRails::RAILS_PROMPT

--- a/lib/pry-rails/prompt.rb
+++ b/lib/pry-rails/prompt.rb
@@ -39,5 +39,3 @@ module PryRails
                  "[1] [project_name][Rails.env] pry(main)>"
   }
 end
-
-Pry.config.prompt = PryRails::RAILS_PROMPT

--- a/lib/pry-rails/prompt.rb
+++ b/lib/pry-rails/prompt.rb
@@ -18,12 +18,20 @@ module PryRails
     end
   end
 
-  RAILS_PROMPT = proc do |target_self, nest_level, pry|
-    "[#{pry.input_array.size}] " \
-      "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
-      "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
-      "#{":#{nest_level}" unless nest_level.zero?}> "
-  end
+  RAILS_PROMPT = [
+    proc do |target_self, nest_level, pry|
+      "[#{pry.input_array.size}] " \
+        "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
+        "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+        "#{":#{nest_level}" unless nest_level.zero?}> "
+    end,
+    proc do |target_self, nest_level, pry|
+      "[#{pry.input_array.size}] " \
+        "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
+        "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+        "#{":#{nest_level}" unless nest_level.zero?}* "
+    end
+  ]
 
   Pry::Prompt::MAP["rails"] = {
     value: RAILS_PROMPT,


### PR DESCRIPTION
edit: I just found https://github.com/rweng/pry-rails/pull/54. In contrast to the old PR, this approach keeps the behaviour of the default pry prompt.

Been pointed here by @r-obert from pry/pry#493. Maybe this is useful.

This adds a new Pry prompt with the current Rails environment and project folder and makes it the default prompt.

I often have multiple rails consoles open and some of them also on production environments to gather data or to cleanup fraudulent users. It would be super helpful if each prompt would show the current project and most importantly the current Rails environment. 

This change to the prompt makes clear what project and environment the current rails console is running on. It should help to prevent people from accidentally deleting/changing data in the wrong environment. That's why I would make it the default promt, but I know that it is a bigger visible change and I'm open about not making it a default.

![2017-02-04-133347_318x32_scrot](https://cloud.githubusercontent.com/assets/2042399/22618513/aa0a2b1e-eade-11e6-8090-95cf3bc96eff.png)
![2017-02-04-133412_311x33_scrot](https://cloud.githubusercontent.com/assets/2042399/22618515/af4848c2-eade-11e6-9e2d-1794d9b53c56.png)

**Questions**
* Default/Not default?
* I'm also not sure if the project name is really needed in the prompt, but I often have multiple projects I'm working on and it was helpful already.
* Rails comes with production, development and test environments by default, so I added the formatting for those (test without any formatting), but maybe this could be improved.
* I didn't add tests due to the open points above