### PR TITLE
Bump minimum required pry version to 0.10.4

### DIFF
--- a/pry-rails.gemspec
+++ b/pry-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "pry", ">= 0.9.10"
+  s.add_dependency "pry", ">= 0.10.4"
   s.add_development_dependency "appraisal"
   s.add_development_dependency "minitest"
 end


### PR DESCRIPTION
Running pry-rails against versions of pry prior to version 0.10.4 will cause a 'uninitialized constant' exception for Pry::Prompt. No class by this name existed prior to version 0.10.4.

I believe [this][1] is the commit that introduced `Pry::Prompt`

[1]: https://github.com/pry/pry/commit/e617c7d42027455e1f49a9be3c18d84eaf7ba536