### PR TITLE
Change show-routes command to allow multiple grep options

### DIFF
--- a/lib/pry-rails/commands/show_routes.rb
+++ b/lib/pry-rails/commands/show_routes.rb
@@ -8,7 +8,9 @@ class PryRails::ShowRoutes < Pry::ClassCommand
   BANNER
 
   def options(opt)
-    opt.on :G, "grep", "Filter output by regular expression", :argument => true
+    opt.on :G, "grep", "Filter output by regular expression",
+           :argument => true,
+           :as => Array
   end
 
   def process
@@ -24,7 +26,29 @@ class PryRails::ShowRoutes < Pry::ClassCommand
         process_rails_3_0_and_3_1(all_routes)
       end
 
-    output.puts formatted.grep(Regexp.new(opts[:G] || ".")).join("\n")
+    output.puts grep_routes(formatted).join("\n")
+  end
+
+  # This method allows multiple grep conditions, like a pipe operator in unix
+  # Input show-routes -G admin -G post
+  # Output admin_post GET /admin/posts/:id(.:format)     admin/posts#show
+
+  # Params
+
+  # formatted
+  # ["          Prefix Verb   URI Pattern                       Controller#Action",
+  #  "             root GET    /                                 blog/posts#index",
+  #  "             post GET    /post(.:format)                   blog/posts#post",
+  #  "             admin_post GET /admin/posts/:id(.:format)     admin/posts#show
+  # ]
+
+  def grep_routes(formatted)
+    return formatted unless opts[:G]
+    grep_opts = opts[:G]
+
+    grep_opts.reduce(formatted) do |grep_opt|
+      formatted.grep(Regexp.new(grep_opt))
+    end
   end
 
   # Cribbed from https://github.com/rails/rails/blob/3-1-stable/railties/lib/rails/tasks/routes.rake

--- a/spec/show_routes_spec.rb
+++ b/spec/show_routes_spec.rb
@@ -12,4 +12,16 @@ describe "show-routes" do
 
     output.must_match %r{^edit_pokemon GET    /pokemon/edit}
   end
+
+  it "should print a list of routes which include grep option" do
+    output = mock_pry('show-routes -G edit', 'exit-all')
+
+    output.must_match %r{^edit_pokemon GET    /pokemon/edit}
+  end
+
+  it "should print a list of routes which include grep option" do
+    output = mock_pry('show-routes -G edit -G pokemon', 'exit-all')
+
+    output.must_match %r{^edit_pokemon GET    /pokemon/edit}
+  end
 end


### PR DESCRIPTION
## Allow multiple grep options for show-routes command.
This PR allows multiple grep conditions, like a pipe operator in unix
##Description of a problem
If I have this set of routes 
```
             Prefix Verb   URI Pattern                       Controller#Action",
             root GET    /                                 blog/posts#index",
             post GET    /post(.:format)                   blog/posts#post",
             admin_post GET /admin/posts/:id(.:format)     admin/posts#show
             admin_user GET /admin/users/:id(.:format)     admin/users#show

```
and wand to find admin post routes in terminal I can use pipe operator.
```
bundle exec rake routes | grep admin | grep post
```
output :
 ````admin_post GET /admin/posts/:id(.:format)     admin/posts#show````

If I try to do the same with show-routes in pry, It will use only first option.
```show-routes -G admin -G post```
outout: 
 ```
             admin_post GET /admin/posts/:id(.:format)     admin/posts#show
             admin_user GET /admin/users/:id(.:format)     admin/users#show
````
## Solution
Refactored PryRails::ShowRoutes#options and PryRails::ShowRoutes#process methods
to alow show-routes command accept multiple grep options
 ````show-routes -G admin -G post ````
output:
 ````admin_post GET /admin/posts/:id(.:format)     admin/posts#show````


   