### PR TITLE
Add support pry-0.12.0

### DIFF
--- a/lib/pry-rails/prompt.rb
+++ b/lib/pry-rails/prompt.rb
@@ -1,3 +1,5 @@
+require 'rubygems'
+
 module PryRails
   class Prompt
     class << self
@@ -18,24 +20,35 @@ module PryRails
     end
   end
 
-  RAILS_PROMPT = [
-    proc do |target_self, nest_level, pry|
-      "[#{pry.input_array.size}] " \
-        "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
-        "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
-        "#{":#{nest_level}" unless nest_level.zero?}> "
-    end,
-    proc do |target_self, nest_level, pry|
-      "[#{pry.input_array.size}] " \
-        "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
-        "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
-        "#{":#{nest_level}" unless nest_level.zero?}* "
-    end
-  ]
+  description = "Includes the current Rails environment and project folder name.\n" \
+                "[1] [project_name][Rails.env] pry(main)>"
 
-  Pry::Prompt::MAP["rails"] = {
-    value: RAILS_PROMPT,
-    description: "Includes the current Rails environment and project folder name.\n" \
-                 "[1] [project_name][Rails.env] pry(main)>"
-  }
+  if Gem::Version.new(Pry::VERSION) < Gem::Version.new('0.12.0')
+    RAILS_PROMPT = [
+      proc do |target_self, nest_level, pry|
+        "[#{pry.input_array.size}] " \
+          "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
+          "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+          "#{":#{nest_level}" unless nest_level.zero?}> "
+      end,
+      proc do |target_self, nest_level, pry|
+        "[#{pry.input_array.size}] " \
+          "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
+          "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+          "#{":#{nest_level}" unless nest_level.zero?}* "
+      end
+    ]
+    Pry::Prompt::MAP["rails"] = {
+      value: RAILS_PROMPT,
+      description: description
+    }
+  else
+    RAILS_PROMPT_PROC = proc do |target_self, nest_level, pry, sep|
+      "[#{pry.input_ring.size}] " \
+        "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
+        "#{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
+        "#{":#{nest_level}" unless nest_level.zero?}#{sep} "
+    end
+    Pry::Prompt.add("rails", description, &RAILS_PROMPT_PROC)
+  end
 end


### PR DESCRIPTION
`Pry::Prompt::Map` and `_pry_.input_array` are deprecated at pry-0.12.0.

https://github.com/pry/pry/blob/master/CHANGELOG.md#v0120-november-5-2018