### PR TITLE
Prompt should not infer `project_name` from the path

### DIFF
--- a/lib/pry-rails/prompt.rb
+++ b/lib/pry-rails/prompt.rb
@@ -13,7 +13,7 @@ module PryRails
       end
 
       def project_name
-        File.basename(Rails.root)
+        Rails.application.class.parent_name.underscore
       end
     end
   end


### PR DESCRIPTION
The existing `project_name` implementation infers itself the directory the application exists in. However, this expectation fails several situations, such as

- Docker conventionally puts applications in /app
- Capistrano conventionally puts applications in /:prefix/project_name/releases/20181126-020459-399a6ff/

Instead, this infers the project name from the `Rails.application` class name, which is set by `rails new`. A similar approach is used in the marco-polo irb prompt gem:

https://github.com/arches/marco-polo/blob/0f53f5645bceac45757f061fc9b53ab2396afda7/lib/marco-polo.rb#L17