### PR TITLE
Use `module_parent_name` instead of `parent_name` for Rails 6.

### DIFF
--- a/lib/pry-rails/prompt.rb
+++ b/lib/pry-rails/prompt.rb
@@ -13,7 +13,11 @@ module PryRails
       end
 
       def project_name
-        Rails.application.class.parent_name.underscore
+        if Rails::VERSION::MAJOR == 6
+          Rails.application.class.module_parent_name.underscore
+        else
+          Rails.application.class.parent_name.underscore
+        end
       end
     end
   end


### PR DESCRIPTION
Hey there,

just a small pull request to fix deprecation warning: `Module#parent_name` has been renamed to `module_parent_name`. `parent_name` is deprecated and will be removed in Rails 6.1.

Many thanks for `pry-rails` and happy new year.

Maik