### PR TITLE
Fix documentation to match correct usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,15 +82,15 @@ If you want to permanently include the current Rails environment and project nam
 in the Pry prompt, put the following lines in your project's `.pryrc`:
 
 ```ruby
-Pry.config.prompt = Pry::Prompt[:rails][:value]
+Pry.config.prompt = Pry::Prompt::MAP["rails"][:value]
 ```
 
 If `.pryrc` could be loaded without pry-rails being available or installed,
 guard against setting `Pry.config.prompt` to `nil`:
 
 ```ruby
-if Pry::Prompt[:rails]
-  Pry.config.prompt = Pry::Prompt[:rails][:value]
+if Pry::Prompt::MAP["rails"]
+  Pry.config.prompt = Pry::Prompt::MAP["rails"][:value]
 end
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -82,17 +82,19 @@ If you want to permanently include the current Rails environment and project nam
 in the Pry prompt, put the following lines in your project's `.pryrc`:
 
 ```ruby
-Pry.config.prompt = Pry::Prompt::MAP["rails"][:value]
+Pry.prompt = Pry::Prompt["rails"][:value]
 ```
 
 If `.pryrc` could be loaded without pry-rails being available or installed,
 guard against setting `Pry.config.prompt` to `nil`:
 
 ```ruby
-if Pry::Prompt::MAP["rails"]
-  Pry.config.prompt = Pry::Prompt::MAP["rails"][:value]
+if Pry::Prompt.all.key?("rails")
+  Pry.prompt = Pry::Prompt["rails"][:value]
 end
 ```
+
+This requires `pry` > v12
 
 Check out `change-prompt --help` for information about temporarily
 changing the prompt for the current Pry session.


### PR DESCRIPTION
A change 10 months ago removed how you could access the custom prompts, this commit updates the documentation to ensure it matches.