### PR TITLE
Update prompt syntax for Pry v0.13.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,7 +82,7 @@ If you want to permanently include the current Rails environment and project nam
 in the Pry prompt, put the following lines in your project's `.pryrc`:
 
 ```ruby
-Pry.config.prompt = Pry::Prompt[:rails][:value]
+Pry.config.prompt = Pry::Prompt[:rails]
 ```
 
 If `.pryrc` could be loaded without pry-rails being available or installed,
@@ -90,7 +90,7 @@ guard against setting `Pry.config.prompt` to `nil`:
 
 ```ruby
 if Pry::Prompt[:rails]
-  Pry.config.prompt = Pry::Prompt[:rails][:value]
+  Pry.config.prompt = Pry::Prompt[:rails]
 end
 ```
 


### PR DESCRIPTION
Version 0.13.0 of Pry changed the way that prompts are configured and added. Specifically, setting the prompt via an array of two procs is now deprecated. This commit updates the README documentation so that warnings are no longer emitted when running `rails console` at the command line and fixes #118.

See the Pry CHANGELOG for more information:
https://github.com/pry/pry/blob/master/CHANGELOG.md