### PR TITLE
Bump minimum required pry version to 0.13.0

### DIFF
--- a/pry-rails.gemspec
+++ b/pry-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "pry", ">= 0.10.4"
+  s.add_dependency "pry", ">= 0.13.0"
   s.add_development_dependency "appraisal"
   s.add_development_dependency "minitest"
 end


### PR DESCRIPTION
This is nice for folks using ruby 2.7, as pry 0.13.0 resolves a
deprecation warning introduced in Ruby 2.7. This warning gets a little
annoying to see everytime you fire up pry.

Ex warning:
```
<main>: warning: __FILE__ in eval may not return location in binding; use Binding#source_location instead
/Users/mykecameron/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/pry-0.12.2/lib/pry/commands/whereami.rb:40: warning: in `eval'
<main>: warning: __LINE__ in eval may not return location in binding; use Binding#source_location instead
/Users/mykecameron/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/pry-0.12.2/lib/pry/commands/whereami.rb:41: warning: in `eval'
```

see: https://github.com/pry/pry/issues/2097#issuecomment-602029140