### PR TITLE
Document feature to disable pry-rails

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,9 +74,6 @@ Pokemon
   updated_at: datetime
   belongs_to hacker
   has_many beers through hacker
-
-$ DISABLE_PRY_RAILS=1 rails console
-irb(main):001:0>
 ```
 
 ## Custom Rails prompt
@@ -99,6 +96,12 @@ end
 
 Check out `change-prompt --help` for information about temporarily
 changing the prompt for the current Pry session.
+
+## Disable pry-rails
+If pry-rails is included in your application but you would prefer not to use it, you may run the following command to set the appropriate environment variable to disable initialization and fall back to the default IRB console:
+```shell
+DISABLE_PRY_RAILS=1 rails console
+```
 
 # Developing and Testing
 

--- a/Readme.md
+++ b/Readme.md
@@ -97,7 +97,7 @@ end
 Check out `change-prompt --help` for information about temporarily
 changing the prompt for the current Pry session.
 
-## Disable pry-rails
+## Disabling pry-rails
 
 If pry-rails is included in your application but you would prefer not to use it, you may run the following command to set the appropriate environment variable to disable initialization and fall back to the default IRB console:
 ```shell

--- a/Readme.md
+++ b/Readme.md
@@ -98,10 +98,13 @@ Check out `change-prompt --help` for information about temporarily
 changing the prompt for the current Pry session.
 
 ## Disable pry-rails
+
 If pry-rails is included in your application but you would prefer not to use it, you may run the following command to set the appropriate environment variable to disable initialization and fall back to the default IRB console:
 ```shell
 DISABLE_PRY_RAILS=1 rails console
 ```
+
+Note that you may need to run `spring stop` first.
 
 # Developing and Testing
 


### PR DESCRIPTION
An example of this feature is currently shown in the README, but it likely warrants being highlighted in its own section.

This should suffice for those desiring a way to opt out when pry is the default. If making pry opt in is what you're looking for, there are some unofficial solutions in [this StackOverflow question](https://stackoverflow.com/q/25145937/2566838).

Closes #110