### PR TITLE
Add prompt support for `--sandbox` flag

### DIFF
--- a/lib/pry-rails/prompt.rb
+++ b/lib/pry-rails/prompt.rb
@@ -19,6 +19,12 @@ module PryRails
           Rails.application.class.parent_name.underscore
         end
       end
+
+      def sandbox_mode
+        return "" unless Rails.application.sandbox?
+
+        "[#{Pry::Helpers::Text.yellow('sandbox: true')}]"
+      end
     end
   end
 
@@ -27,14 +33,14 @@ module PryRails
   if Pry::Prompt.respond_to?(:add)
     Pry::Prompt.add 'rails', desc, %w(> *) do |target_self, nest_level, pry, sep|
       "[#{pry.input_ring.size}] " \
-      "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
+      "[#{Prompt.project_name}][#{Prompt.formatted_env}]#{Prompt.sandbox_mode} " \
       "#{pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
       "#{":#{nest_level}" unless nest_level.zero?}#{sep} "
     end
   else
     draw_prompt = lambda do |target_self, nest_level, pry, sep|
       "[#{pry.input_array.size}] " \
-      "[#{Prompt.project_name}][#{Prompt.formatted_env}] " \
+      "[#{Prompt.project_name}][#{Prompt.formatted_env}]#{Prompt.sandbox_mode} " \
       "#{pry.config.prompt_name}(#{Pry.view_clip(target_self)})" \
       "#{":#{nest_level}" unless nest_level.zero?}#{sep} "
     end


### PR DESCRIPTION
# Why

The existing `Pry.config.prompt = Pry::Prompt[:rails]` is excellent at showing project and environment. This adds support for showin Rails built-in sandbox mode as part of Pry display.

# What
`rails console --sandbox`
<img width="839" height="98" alt="image" src="https://github.com/user-attachments/assets/0bb06830-d3e8-47e2-a176-929fcb0aed56" />

`rails console`
<img width="839" height="78" alt="image" src="https://github.com/user-attachments/assets/b73abe21-1b0a-44d6-b6ea-fd6848112a7b" />
